### PR TITLE
Feature: Fire progress after resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ The `progress` method will return the value resolved by the current executing pr
       }
     });
 
+**NOTE**: The progress callback can be attached even after Continuity
+has resolved. Such is the nature of promises that it matters not when
+the "thenable" functions are called, so `progress` works the same. The
+progess callback will execute for each resolved value just as it would
+if it were attached before any were resolved.
+
 ## Running Tests
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -58,15 +58,23 @@
  * @return {Continuity} for thenable methods and progress callback
  * @public
  */
-var Continuity = function(collection, iterationFn) {
+var Continuity = function(originalCollection, iterationFn) {
   var continuity,
       promise,
       reject,
       resolve,
-      progressCallbacks;
+      progressCallbacks,
+      collection,
+      values;
 
   // Empty array of progress callbacks
   progressCallbacks = [];
+
+  // Initialize empty array of values
+  values = [];
+
+  // Clone collection
+  collection = Array.prototype.slice.call(originalCollection);
 
 
   /**
@@ -78,9 +86,7 @@ var Continuity = function(collection, iterationFn) {
    * @param {Array} values that have been returned from promises
    * @private
    */
-  function collectionIterator(collection, values) {
-    collection = Array.prototype.slice.call(collection);
-    values = Array.prototype.slice.call(values);
+  function collectionIterator(collection) {
 
     // Create iteration promise to pass resolver and rejecter into function
     new Promise(function(iterationResolve, iterationReject) {
@@ -140,6 +146,9 @@ var Continuity = function(collection, iterationFn) {
   };
 
   this.progress = function(callback) {
+    values.map(function(value, index) {
+      callback(value, originalCollection[index], values.slice(0, index + 1), index + 1);
+    });
     progressCallbacks.push(callback);
     return this;
   };

--- a/test/continuity_spec.js
+++ b/test/continuity_spec.js
@@ -14,7 +14,7 @@ describe('Continuity', function() {
   });
 
   function runContinuitySequence(done) {
-    new Continuity(initialValues, function(value, resolve, reject) {
+    return new Continuity(initialValues, function(value, resolve, reject) {
       if ( !isNaN(value) ) {
         if ( value !== 100 ) {
           resolve(value + 10);
@@ -119,6 +119,61 @@ describe('Continuity', function() {
 
     it("fails if one promise fails", function(){
       assert(errorMessage == 'Not a number dummy');
+    });
+  });
+
+  describe('with progress attached after promises resolved', function() {
+    var continuity;
+
+    beforeEach(function(done) {
+      initialValues = [1, 10];
+      continuity = runContinuitySequence(done);
+    });
+
+    it('fires progress function for all resolved values', function() {
+      var valueSum;
+      valueSum = 0;
+
+      continuity.progress(function(value) {
+        valueSum += value;
+      });
+
+      assert(valueSum == 31);
+    });
+
+    it('fires progress function for all collection values', function() {
+      var collectionSum;
+      collectionSum = 0;
+
+      continuity.progress(function(value, originalValue) {
+        collectionSum += originalValue;
+      });
+
+      assert(collectionSum == 11);
+    });
+
+    it('fires progress function for all arrays of resolved values', function() {
+      var resolvedValues;
+      resolvedValues = [];
+
+      continuity.progress(function(value, originalValue, values) {
+        resolvedValues.push(values);
+      });
+
+      assert(resolvedValues[0][0] == 11);
+      assert(resolvedValues[1][0] == 11);
+      assert(resolvedValues[1][1] == 20);
+    });
+
+    it('fires progress function for all progress values', function() {
+      var progressSum;
+      progressSum = 0;
+
+      continuity.progress(function(value, originalValue, values, progress) {
+        progressSum += progress;
+      });
+
+      assert(progressSum == 3);
     });
   });
 });


### PR DESCRIPTION
The progress callback can be attached even after Continuity
has resolved. Such is the nature of promises that it matters not when
the "thenable" functions are called, so `progress` works the same. The
progess callback will execute for each resolved value just as it would
if it were attached before any were resolved.

Resolves issue: https://github.com/rsnorman/continuity/issues/3
