### PR TITLE
Bug fix: Fix issue when initialized with empty array

### DIFF
--- a/index.js
+++ b/index.js
@@ -389,7 +389,9 @@ var Continuity = function(originalCollection, iterationFn) {
 
 
   // Start iterating through collection
-  collectionIterator();
+  if ( valueQueue.length > 0 ) {
+    collectionIterator();
+  }
 
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promise-continuity",
   "description": "Sequential promise iteration made easy",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Ryan Norman <rsnorman15@gmail.com> (http://github.com/rsnorman)",
   "keywords": ["promise", "chain", "sequential", "array"],
   "repository" : {

--- a/test/continuity_spec.js
+++ b/test/continuity_spec.js
@@ -75,6 +75,17 @@ describe('Continuity', function() {
       createContinuity(startValues).then(setValues);
     }
 
+    describe('with no elements in collection', function() {
+      beforeEach(function(done) {
+        runContinuity([]);
+        tick().then(done);
+      });
+
+      it('sets values to resolved', function(){
+        assert.equal(values.length, 0);
+      });
+    });
+
     describe('with one element in collection', function() {
       beforeEach(function(){
         runContinuity([1]);
@@ -536,6 +547,20 @@ describe('Continuity', function() {
           continuity.queue(5);
         }, 'All values resolved, cannot push another value');
       });
+    });
+  });
+
+  describe('with initial empty collection', function() {
+    beforeEach(function(done) {
+      continuity = createContinuity([]);
+      continuity.queue(5).then(function(_values) {
+        setValues(_values);
+        done();
+      });
+    });
+
+    it('sets all values', function() {
+      assert.equal(values[0], 15);
     });
   });
 


### PR DESCRIPTION
# Issue

When a collection is initialize with an empty array it will never resolve
# Solution

Don't start iterating over collection if there are no elements

Fixes: https://github.com/rsnorman/continuity/issues/17
